### PR TITLE
some better mac instructions

### DIFF
--- a/src/gui/pages/index.vue
+++ b/src/gui/pages/index.vue
@@ -20,6 +20,13 @@
       <!-- Quick Upload -->
       <nudity-upload v-if="validCliDir && validCheckpointsDir" />
 
+      <!-- No deeptools -->
+      <div v-if="!deepToolsMissing" class="notification is-danger">
+        <strong>❌ Hold on!</strong><br />
+        It looks like you are not accessing this application from the electron app in dev mode.<br/>
+        You need to make sure you run <code>yarn dev-gui</code> and access the server from the window that opens.<br/><br/>
+        Join our Discord for more information.
+      </div>
       <!-- CLI Dir -->
       <div v-if="!validCliDir" class="notification is-danger">
         <strong>❌ Hold on!</strong><br />
@@ -54,6 +61,11 @@ export default {
   }),
 
   created() {
+    this.deepToolsMissing = false;
+    if(!window.deepTools) {
+      this.deepToolsMissing = true;
+      return;
+    }
     this.cliDirPath = window.deepTools.getCliDirPath()
     this.validCliDir = window.deepTools.fs.exists(this.cliDirPath)
 

--- a/src/scripts/mac/README.md
+++ b/src/scripts/mac/README.md
@@ -1,7 +1,39 @@
 ## macOS Scripts
 
-In this folder should go the scripts to install, compile and run the project in macOS, but... I do not have a Mac (so poor FeelsBadMan) so the scripts are the same as those of Linux.
+In this folder should go the scripts to install, compile and run the project in macOS.
 
+### Running these scripts 
+You will need to add execute permissions to each one of these scripts to run them. Do this for all scripts you want to run:
+
+```bash
+chmod +x build.sh
+./build.sh
+```
+### Issues you may encounter
+
+You will need to have python 3.6 installed because that is what the author uses. I had less issues after installing it.
+Assuming you have homebrew installed, do this:
+
+```bash
+brew unlink python
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a764ef944b1080be64bd88dca9a1d80130c558/Formula/python.rb
+```
+----
+
+Pytorch fails with `Library not loaded: /usr/local/opt/libomp/lib/libomp.dylib`
+
+run
+
+```bash
+brew install libomp
+```
+----
+
+You cannot build the electron app.
+
+No idea yet, run the dev server or the CLI and it works.
+
+---
 Please do not hesitate to do a PR if you have a Mac and you can correct these files!
 
 **⚠ Note:**

--- a/src/scripts/mac/setup.sh
+++ b/src/scripts/mac/setup.sh
@@ -15,7 +15,7 @@ cd ../../cli
 pip3 --no-cache-dir install pyinstaller
 
 # This command should resolve and install all the necessary packages
-pip3 --no-cache-dir install -r requirements-ubuntu.txt
+pip3 --no-cache-dir install -r requirements-mac.txt
 
 # NOTES from wisp101:
 # Make sure pyinstaller is accessible from the cmdline as "pyinstaller".
@@ -47,5 +47,5 @@ yarn install --force --no-lockfile
 #
 
 echo "Installation completed!"
-echo "- Now you can run the dev-start.bat script to start modifying the GUI and see the changes in real time."
-echo "- Now you can run the build.bat script to compile the project and get an easy-to-use binary"
+echo "- Now you can run the dev-start.sh script to start modifying the GUI and see the changes in real time."
+echo "- Now you can run the build.sh script to compile the project and get an easy-to-use binary"


### PR DESCRIPTION
also added some idiot proofing to both docs and app.

By the way, `dev-start.sh` for mac is wrong, but my bash-foo is not strong enough to fix it.

```bash
sh yarn dev
sh yarn dev-gui
```

The first command never finishes, so the 2nd one never runs. 